### PR TITLE
Enable BlueCompute Web App to run behind a proxy

### DIFF
--- a/StoreWebApp/app.js
+++ b/StoreWebApp/app.js
@@ -19,6 +19,9 @@ var app = express();
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
 
+// enable app to run behind a proxy
+app.set('trust proxy', true);
+
 app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
 app.use(bodyParser.json());


### PR DESCRIPTION
BlueCompute app is a node.js application using express framework. By default express framework doesn't allow the application to run behind a proxy. 
I've explicitly enable that as documented at the following link:
      http://expressjs.com/en/guide/behind-proxies.html

